### PR TITLE
fix: serialization of writes to Windows secure storage.

### DIFF
--- a/packages/stow/lib/src/abstract_stow.dart
+++ b/packages/stow/lib/src/abstract_stow.dart
@@ -50,6 +50,7 @@ abstract class Stow<Key, Value, EncodedValue> extends ChangeNotifier
     notifyListeners();
   }
 
+  final _readMutex = Mutex();
 
   @override
   Value get value => _value;

--- a/packages/stow/lib/src/abstract_stow.dart
+++ b/packages/stow/lib/src/abstract_stow.dart
@@ -4,6 +4,11 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:meta/meta.dart';
 import 'package:mutex/mutex.dart';
+import 'package:synchronized/synchronized.dart';
+
+
+final Lock globalStorageWriteLock = Lock(); // important to write to Windows secure storage, to serialize writes between instances of Stow
+
 
 /// An abstract class that allows synchronous access to a value
 /// from some asynchronous storage. Actual implementations may vary.

--- a/packages/stow/lib/src/abstract_stow.dart
+++ b/packages/stow/lib/src/abstract_stow.dart
@@ -4,10 +4,8 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:meta/meta.dart';
 import 'package:mutex/mutex.dart';
-import 'package:synchronized/synchronized.dart';
 
-
-final Lock globalStorageWriteLock = Lock(); // important to write to Windows secure storage, to serialize writes between instances of Stow
+final _writeMutex = Mutex();   // write mutex must be common to all instances to achieve serialization of writes
 
 
 /// An abstract class that allows synchronous access to a value
@@ -52,8 +50,6 @@ abstract class Stow<Key, Value, EncodedValue> extends ChangeNotifier
     notifyListeners();
   }
 
-  final _readMutex = Mutex();
-  final _writeMutex = Mutex();
 
   @override
   Value get value => _value;

--- a/packages/stow_secure/lib/src/secure_stow.dart
+++ b/packages/stow_secure/lib/src/secure_stow.dart
@@ -104,14 +104,12 @@ class SecureStow<Value> extends Stow<String, Value, String?> {
 
 @override
   Future<void> protectedWrite(String? encodedValue) async {
-    await globalStorageWriteLock.synchronized(() async {   // serialize writes between Stow instances, important on Windows
-      if (encodedValue == null || encodedValue == encodedDefaultValue) {
-        await storage.delete(key: key);
-      } else {
-        await storage.write(key: key, value: encodedValue);
-      }
-    });
-  }
+    if (encodedValue == null || encodedValue == encodedDefaultValue) {
+      await storage.delete(key: key);
+    } else {
+      await storage.write(key: key, value: encodedValue);
+    }
+}
 
   @override
   String toString() => 'SecureStow<$Value>($key, $value, $codec)';

--- a/packages/stow_secure/lib/src/secure_stow.dart
+++ b/packages/stow_secure/lib/src/secure_stow.dart
@@ -102,13 +102,15 @@ class SecureStow<Value> extends Stow<String, Value, String?> {
   @override
   Future<String?> protectedRead() async => storage.read(key: key);
 
-  @override
+@override
   Future<void> protectedWrite(String? encodedValue) async {
-    if (encodedValue == null || value == encodedDefaultValue) {
-      await storage.delete(key: key);
-    } else {
-      await storage.write(key: key, value: encodedValue);
-    }
+    await globalStorageWriteLock.synchronized(() async {   // serialize writes between Stow instances, important on Windows
+      if (encodedValue == null || encodedValue == encodedDefaultValue) {
+        await storage.delete(key: key);
+      } else {
+        await storage.write(key: key, value: encodedValue);
+      }
+    });
   }
 
   @override


### PR DESCRIPTION
current Stow implementation does not work on Windows if you try to write for example 4 keys fast after each other. In this case are not writes of different objects serialized.  This fix helped me to make it work on Windows.

It will be useful to write test case storing 4 values and test it on Windows.